### PR TITLE
Fix second argument for `.splice`

### DIFF
--- a/exercises/46 - Arrays/array-methods.html
+++ b/exercises/46 - Arrays/array-methods.html
@@ -107,7 +107,7 @@
     // Make a copy of the toppings array with a spread
     const toppingsCopy2 = [...toppings];
     // take out items 3 to 5 of your new toppings array with splice()
-    toppingsCopy.splice(3, 5);
+    toppingsCopy.splice(3, 3);
     console.log(toppingsCopy);
     // find the index of Avocado with indexOf() / lastIndexOf()
     const avoIndex = toppings.indexOf('Avocado');


### PR DESCRIPTION
`Line 109`: In this exercise, we have to remove items 3 to 5 with `.splice`, i.e. we have to remove a total of 3 items (assumed from index 3 to index 5).

You passed in `(3, 5)` for the `.splice` method and this will result in the removal of 5 items starting at index 3. To remove items 3 to 5 (3 items), you should pass in `(3, 3)` for the `.splice` method, since the second argument corresponds to the amount of items to remove.