### PR TITLE
Fix typo in grid property name declaration (grid-gap)

### DIFF
--- a/exercises/59 - Slider/style.scss
+++ b/exercises/59 - Slider/style.scss
@@ -1,7 +1,7 @@
 .slides {
   width: 800px;
   height: 500px;
-  border:2px solid black;
+  border: 2px solid black;
   position: relative;
   margin: 0 auto;
   overflow: hidden;
@@ -23,7 +23,7 @@
   transform: translateX(-200%);
 }
 
-.slide.next + .slide {
+.slide.next+.slide {
   transform: translateX(200%);
 }
 
@@ -31,10 +31,12 @@
   z-index: 10;
   transform: translateX(-100%);
 }
+
 .slide.current {
   z-index: 10;
   transform: translateX(0);
 }
+
 .slide.next {
   z-index: 10;
   transform: translateX(100%);
@@ -43,7 +45,7 @@
 .controls {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 200px));
-  gap: 2rem;
+  grid-gap: 2rem;
   justify-content: center;
   padding: 2rem;
 }


### PR DESCRIPTION
Fix typo when declaring the `grid-gap` property (for the `.controls` class). It was declared as `gap: 2rem;` and it should be `grid-gap: 2rem;`.

P.S. Additional spacing changes were introduced by the Beautifier extension, which I couldn't stop it from doing so, I hope it is not a problem.