### PR TITLE
Fix for browser support check

### DIFF
--- a/exercises/84 - Web Speech Colour Game/speech-FINISHED.js
+++ b/exercises/84 - Web Speech Colour Game/speech-FINISHED.js
@@ -19,7 +19,7 @@ window.SpeechRecognition =
 
 function start() {
   // see if their browser supports this
-  if (!("SpeechRecognition" in window)) {
+  if (!window.SpeechRecognition) {
     console.log("Sorry your browser does not support speech reco. ");
     return;
   }


### PR DESCRIPTION
Instead of checking if the variable exists in window, we should check the value of the variable instead. The variable will always exist in window because it has been defined beforehand.
![Screen Shot 2020-05-27 at 18 26 13](https://user-images.githubusercontent.com/66032213/83060206-03850380-a053-11ea-9631-052ac7f40c6d.png)
![Screen Shot 2020-05-27 at 18 38 38](https://user-images.githubusercontent.com/66032213/83060238-0bdd3e80-a053-11ea-97f9-d71b9e0539ae.png)
