### PR TITLE
update parcel-cache in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 haters/
 .cache/
 dist/
+.parcel-cache/


### PR DESCRIPTION
Hi Wes and team!

In your videos, Parcel generates a directory named .cache but it is now called .parcel-cache. I left .cache/ in the gitignore in case others had old versions but happy to remove that if you want.