### PR TITLE
fix: convert dataset values to numbers in async typer

### DIFF
--- a/exercises/73 - Async Typer/scripts-FINISHED.js
+++ b/exercises/73 - Async Typer/scripts-FINISHED.js
@@ -6,25 +6,14 @@ function getRandomBetween(min = 20, max = 150, randomNumber = Math.random()) {
   return Math.floor(randomNumber * (max - min) + min);
 }
 
-// async for of loop
-// async function draw(el) {
-//   const text = el.textContent;
-//   let soFar = '';
-//   for (const letter of text) {
-//     soFar += letter;
-//     el.textContent = soFar;
-//     // wait for some amount of time
-//     const { typeMin, typeMax } = el.dataset;
-//     const amountOfTimeToWait = getRandomBetween(typeMin, typeMax);
-//     await wait(amountOfTimeToWait);
-//   }
-// }
+
 
 // recursion
 function draw(el) {
   let index = 1;
   const text = el.textContent;
-  const { typeMin, typeMax } = el.dataset;
+  const typeMin = parseInt(el.dataset.typeMin, 10);
+  const typeMax = parseInt(el.dataset.typeMax, 10);
   async function drawLetter() {
     el.textContent = text.slice(0, index);
     index += 1;


### PR DESCRIPTION
## Summary

Fixes the Async Typer issue where `getRandomBetween()` receives string values from `el.dataset`.

## Changes Made

- Converted `typeMin` and `typeMax` from strings to numbers using `parseInt`.
- Ensured `getRandomBetween()` always receives numeric arguments.

## Why

Dataset values are always returned as strings. Passing them directly can lead to unexpected behavior and type-related bugs.

Fixes #230