### PR TITLE
Fix broken image URLs in DOM exercise finished HTML

### DIFF
--- a/exercises/20 - The DOM/index-FINISHED.html
+++ b/exercises/20 - The DOM/index-FINISHED.html
@@ -11,18 +11,18 @@
 
   <body>
     <p class="wes">I am Wes, I <em>love</em> to bbq and <strong>Make websites!</strong></p>
-    <img class="nice cool" src="https://picsum.photos/500" />
+    <img class="nice cool" src="https://picsum.photos/seed/picsum/500/500" />
 
     <div class="items">
       <div class="item">
-        <img class="custom" data-last="bos" data-name="wes" src="https://picsum.photos/200" />
+        <img class="custom" data-last="bos" data-name="wes" src="https://picsum.photos/seed/picsum/200/200" />
         <img data-name="kait" src="https://picsum.photos/200" />
-        <img data-name="lux" src="https://picsum.photos/200" />
+        <img data-name="lux" src="https://picsum.photos/seed/picsum/200/200" />
 
         <p>Hi I'm a item</p>
       </div>
       <div class="item item2">
-        <img src="https://picsum.photos/200" />
+        <img src="https://picsum.photos/seed/picsum/200/200" />
         <h2>
           I am a heading
           <span>I am hidden!</span>

--- a/exercises/20 - The DOM/index-FINISHED.html
+++ b/exercises/20 - The DOM/index-FINISHED.html
@@ -16,7 +16,7 @@
     <div class="items">
       <div class="item">
         <img class="custom" data-last="bos" data-name="wes" src="https://picsum.photos/seed/picsum/200/200" />
-        <img data-name="kait" src="https://picsum.photos/200" />
+        <img data-name="kait" src="https://picsum.photos/seed/picsum/200/200" />
         <img data-name="lux" src="https://picsum.photos/seed/picsum/200/200" />
 
         <p>Hi I'm a item</p>


### PR DESCRIPTION
## Description

This PR fixes broken images in the finished version of the DOM exercise.

The image URLs were using outdated `picsum.photos` endpoints that no longer load correctly in some environments. Updated the image sources to use working Picsum seed-based URLs so the exercise displays images as expected.

## Changes Made

- Updated image URLs in:
  - `exercises/20 - The DOM/index-FINISHED.html`
- Replaced deprecated Picsum URLs with valid seed-based URLs.
- Restored image rendering in the finished exercise.

## Testing

- Opened `index-FINISHED.html`
- Verified that all images load correctly
- Confirmed that no other functionality was affected

## Related Issue

Fixes #206